### PR TITLE
Introduce a terrible hack to reduce memory usage and a few other less significant changes

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -124,14 +124,15 @@ export default new Command({
             number: new Command({
                 description: "Amount of messages to delete.",
                 async run($: CommonLibrary): Promise<any> {
+                    if ($.channel.type === "dm") {
+                        await $.channel.send("Can't clear messages in the DMs!");
+                        return;
+                    }
                     $.message.delete();
                     const fetched = await $.channel.messages.fetch({
                         limit: $.args[0]
                     });
-                    $.channel
-                        /// @ts-ignore
-                        .bulkDelete(fetched)
-                        .catch((error: any) => $.channel.send(`Error: ${error}`));
+                    await $.channel.bulkDelete(fetched);
                 }
             })
         }),

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -158,8 +158,7 @@ export default new Command({
             permission: Command.PERMISSIONS.BOT_SUPPORT,
             async run($: CommonLibrary): Promise<any> {
                 const nickName = $.args.join(" ");
-                const trav = $.guild?.members.cache.find((member) => member.id === $.client.user?.id);
-                await trav?.setNickname(nickName);
+                await $.guild?.me?.setNickname(nickName);
                 if (botHasPermission($.guild, Permissions.FLAGS.MANAGE_MESSAGES))
                     $.message.delete({timeout: 5000}).catch($.handler.bind($));
                 $.channel.send(`Nickname set to \`${nickName}\``).then((m) => m.delete({timeout: 5000}));

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -76,10 +76,13 @@ export default new Command({
             description: "Displays info about the current guild.",
             async run($: CommonLibrary): Promise<any> {
                 if ($.guild) {
+                    const members = await $.guild.members.fetch({
+                        withPresences: true,
+                        force: true
+                    });
                     const roles = $.guild.roles.cache
                         .sort((a, b) => b.position - a.position)
                         .map((role) => role.toString());
-                    const members = $.guild.members.cache;
                     const channels = $.guild.channels.cache;
                     const emojis = $.guild.emojis.cache;
                     const iconURL = $.guild.iconURL({dynamic: true});

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,6 +1,4 @@
 import {MessageEmbed, version as djsversion} from "discord.js";
-/// @ts-ignore
-import {version} from "../../package.json";
 import ms from "ms";
 import os from "os";
 import Command from "../core/command";
@@ -8,6 +6,8 @@ import {CommonLibrary, formatBytes, trimArray} from "../core/lib";
 import {verificationLevels, filterLevels, regions, flags} from "../defs/info";
 import moment from "moment";
 import utc from "moment";
+
+const {version} = require("../../package.json");
 
 export default new Command({
     description: "Command to provide all sorts of info about the current server, a user, etc.",
@@ -36,13 +36,6 @@ export default new Command({
             async run($: CommonLibrary): Promise<any> {
                 const core = os.cpus()[0];
                 const embed = new MessageEmbed()
-                    .setThumbnail(
-                        /// @ts-ignore
-                        $.client.user?.displayAvatarURL({
-                            dynamic: true,
-                            size: 2048
-                        })
-                    )
                     .setColor($.guild?.me?.displayHexColor || "BLUE")
                     .addField("General", [
                         `**❯ Client:** ${$.client.user?.tag} (${$.client.user?.id})`,
@@ -71,6 +64,11 @@ export default new Command({
                         `\u3000 • Used: ${formatBytes(process.memoryUsage().heapUsed)}`
                     ])
                     .setTimestamp();
+                const avatarURL = $.client.user?.displayAvatarURL({
+                    dynamic: true,
+                    size: 2048
+                });
+                if (avatarURL) embed.setThumbnail(avatarURL);
                 $.channel.send(embed);
             }
         }),
@@ -156,8 +154,7 @@ export default new Command({
                 .sort((a: {position: number}, b: {position: number}) => b.position - a.position)
                 .map((role: {toString: () => any}) => role.toString())
                 .slice(0, -1);
-            // @ts-ignore - Discord.js' typings seem to be outdated here. According to their v12 docs, it's User.fetchFlags() instead of User.flags.
-            const userFlags = ((await member.user.fetchFlags()) as UserFlags).toArray();
+            const userFlags = (await member.user.fetchFlags()).toArray();
 
             const embed = new MessageEmbed()
                 .setThumbnail(member.user.displayAvatarURL({dynamic: true, size: 512}))
@@ -183,10 +180,7 @@ export default new Command({
                     `**❯ Server Join Date:** ${moment(member.joinedAt).format("LL LTS")}`,
                     `**❯ Hoist Role:** ${member.roles.hoist ? member.roles.hoist.name : "None"}`,
                     `**❯ Roles:** [${roles.length}]: ${
-                        roles.length == 0 ? "None"
-                            : roles.length <= 10
-                                ? roles.join(", ")
-                                : trimArray(roles).join(", ")
+                        roles.length == 0 ? "None" : roles.length <= 10 ? roles.join(", ") : trimArray(roles).join(", ")
                     }`
                 ]);
             $.channel.send(embed);

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -145,7 +145,7 @@ export default new Command({
         description: "Displays info about mentioned user.",
         async run($: CommonLibrary): Promise<any> {
             // Transforms the User object into a GuildMember object of the current guild.
-            const member = $.guild?.members.resolve($.args[0]) ?? (await $.guild?.members.fetch($.args[0]));
+            const member = await $.guild?.members.fetch($.args[0]);
 
             if (!member)
                 return $.channel.send(

--- a/src/commands/utilities/desc.ts
+++ b/src/commands/utilities/desc.ts
@@ -9,15 +9,14 @@ export default new Command({
 
         if (!voiceChannel) return $.channel.send("You are not in a voice channel.");
 
-        if (!$.guild?.me?.hasPermission("MANAGE_CHANNELS"))
+        if (!voiceChannel.guild.me?.hasPermission("MANAGE_CHANNELS"))
             return $.channel.send("I am lacking the required permissions to perform this action.");
 
         if ($.args.length === 0) return $.channel.send("Please provide a new voice channel name.");
 
-        const changeVC = $.guild.channels.resolve(voiceChannel.id);
-        $.channel
-            .send(`Changed channel name from "${voiceChannel}" to "${$.args.join(" ")}".`)
-            /// @ts-ignore
-            .then(changeVC?.setName($.args.join(" ")));
+        const prevName = voiceChannel.name;
+        const newName = $.args.join(" ");
+        await voiceChannel.setName(newName);
+        await $.channel.send(`Changed channel name from "${prevName}" to "${newName}".`);
     }
 });

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -182,12 +182,16 @@ export async function loadCommands(): Promise<Collection<string, Command>> {
                 if (cmd.isDirectory()) {
                     if (cmd.name === "subcommands") continue;
                     else $.warn(`You can't have multiple levels of directories! From: "dist/commands/${cmd.name}"`);
-                } else loadCommand(cmd.name, list, selected.name);
+                } else if (cmd.name.endsWith(".js")) {
+                    loadCommand(cmd.name, list, selected.name);
+                }
             }
 
             subdir.close();
             categories.set(category, list);
-        } else loadCommand(selected.name, listMisc);
+        } else if (selected.name.endsWith(".js")) {
+            loadCommand(selected.name, listMisc);
+        }
     }
 
     dir.close();
@@ -236,7 +240,7 @@ export default new Command({
 	permission: null,
 	aliases: [],
 	async run($: CommonLibrary): Promise<any> {
-		
+
 	},
 	subcommands: {
 		layer: new Command({
@@ -246,7 +250,7 @@ export default new Command({
 			permission: null,
 			aliases: [],
 			async run($: CommonLibrary): Promise<any> {
-				
+
 			}
 		})
 	},
@@ -256,7 +260,7 @@ export default new Command({
 		usage: '',
 		permission: null,
 		async run($: CommonLibrary): Promise<any> {
-			
+
 		}
 	}),
 	number: new Command({
@@ -265,7 +269,7 @@ export default new Command({
 		usage: '',
 		permission: null,
 		async run($: CommonLibrary): Promise<any> {
-			
+
 		}
 	}),
 	any: new Command({
@@ -274,7 +278,7 @@ export default new Command({
 		usage: '',
 		permission: null,
 		async run($: CommonLibrary): Promise<any> {
-			
+
 		}
 	})
 });`;

--- a/src/core/lib.ts
+++ b/src/core/lib.ts
@@ -172,7 +172,7 @@ export function formatUTCTimestamp(now = new Date()) {
 }
 
 export function botHasPermission(guild: Guild | null, permission: number): boolean {
-    return !!(client.user && guild?.members.resolve(client.user)?.hasPermission(permission));
+    return !!(guild?.me?.hasPermission(permission));
 }
 
 export function updateGlobalEmoteRegistry(): void {

--- a/src/core/lib.ts
+++ b/src/core/lib.ts
@@ -554,7 +554,6 @@ export abstract class GenericStructure {
 
     public save(asynchronous = true) {
         const tag = this.__meta__;
-        /// @ts-ignore
         delete this.__meta__;
         FileManager.write(tag, this, asynchronous);
         this.__meta__ = tag;

--- a/src/core/lib.ts
+++ b/src/core/lib.ts
@@ -172,7 +172,7 @@ export function formatUTCTimestamp(now = new Date()) {
 }
 
 export function botHasPermission(guild: Guild | null, permission: number): boolean {
-    return !!(guild?.me?.hasPermission(permission));
+    return !!guild?.me?.hasPermission(permission);
 }
 
 export function updateGlobalEmoteRegistry(): void {
@@ -216,20 +216,22 @@ $.paginate = async (
 
         callback(page);
     };
+    const BACKWARDS_EMOJI = "⬅️";
+    const FORWARDS_EMOJI = "➡️";
     const handle = (emote: string, reacterID: string) => {
         switch (emote) {
-            case "⬅️":
+            case BACKWARDS_EMOJI:
                 turn(-1);
                 break;
-            case "➡️":
+            case FORWARDS_EMOJI:
                 turn(1);
                 break;
         }
     };
 
     // Listen for reactions and call the handler.
-    await message.react("⬅️");
-    await message.react("➡️");
+    let backwardsReaction = await message.react(BACKWARDS_EMOJI);
+    let forwardsReaction = await message.react(FORWARDS_EMOJI);
     eventListeners.set(message.id, handle);
     await message.awaitReactions(
         (reaction, user) => {
@@ -248,8 +250,8 @@ $.paginate = async (
     );
     // When time's up, remove the bot's own reactions.
     eventListeners.delete(message.id);
-    message.reactions.cache.get("⬅️")?.users.remove(message.author);
-    message.reactions.cache.get("➡️")?.users.remove(message.author);
+    backwardsReaction.users.remove(message.author);
+    forwardsReaction.users.remove(message.author);
 };
 
 // Waits for the sender to either confirm an action or let it pass (and delete the message).

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Client} from "discord.js";
+import * as discord from "discord.js";
 import setup from "./setup";
 import {Config} from "./core/structures";
 import {loadCommands} from "./core/command";
@@ -6,9 +6,37 @@ import {loadEvents} from "./core/event";
 import "discord.js-lavalink-lib";
 import LavalinkMusic from "discord.js-lavalink-lib";
 
+declare module "discord.js" {
+    interface Presence {
+        patch(data: any): void;
+    }
+}
+
+// The terrible hacks were written by none other than The Noble Programmer On The White PC.
+
+// NOTE: Terrible hack ahead!!! In order to reduce the memory usage of the bot
+// we only store the information from presences that we actually end up using,
+// which currently is only the (online/idle/dnd/offline/...) status (see
+// `src/commands/info.ts`). What data is retrieved from the `data` object
+// (which contains the data received from the Gateway) and how can be seen
+// here:
+// <https://github.com/discordjs/discord.js/blob/cee6cf70ce76e9b06dc7f25bfd77498e18d7c8d4/src/structures/Presence.js#L81-L110>.
+const oldPresencePatch = discord.Presence.prototype.patch;
+discord.Presence.prototype.patch = function patch(data: any) {
+    oldPresencePatch.call(this, {status: data.status});
+};
+
 // This is here in order to make it much less of a headache to access the client from other files.
 // This of course won't actually do anything until the setup process is complete and it logs in.
-export const client = new Client();
+export const client = new discord.Client();
+
+// NOTE: Terrible hack continued!!! Unfortunately we can't receive the presence
+// data at all when the GUILD_PRESENCES intent is disabled, so while we do
+// waste network bandwidth and the CPU time for decoding the incoming packets,
+// the function which handles those packets is NOP-ed out, which, among other
+// things, skips the code which caches the referenced users in the packet. See
+// <https://github.com/discordjs/discord.js/blob/cee6cf70ce76e9b06dc7f25bfd77498e18d7c8d4/src/client/actions/PresenceUpdate.js#L7-L41>.
+(client["actions"] as any)["PresenceUpdate"].handle = () => {};
 
 (client as any).music = LavalinkMusic(client, {
     lavalink: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "rootDir": "src",
         "outDir": "dist",
-        "target": "ES6",
+        "target": "es2019",
         "module": "CommonJS",
         "moduleResolution": "node",
         "esModuleInterop": true,
@@ -11,7 +11,8 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "strictPropertyInitialization": true,
-        "removeComments": true
+        "removeComments": true,
+        "sourceMap": true
     },
     "exclude": ["test"]
 }


### PR DESCRIPTION
1. Add the titular hack:tm: aka "pulling CC modding on discord.js".
2. Reduce the usage of caches where possible (don't remember whether I eliminated all of them or not; note that guild members, roles and emojis can be assumed to be always cached if the guild object is available), especially in the info command (because I have effectively broken the automatic members cache with the titular hack). Also get rid of calls to `BaseManager#resolve` to make cache lookups explicit.
3. Get rid of usages of `@ts-ignore` (never do this, or I'll kill you!!!).
4. Enable sourcemaps for seeing the source code lines in the error stack traces.
5. Raise the target JS edition to ES2019 since Node.js installed on the deployment machine is version 15.x anyway.

P.S. Just read the diffs
P.P.S. The hack has been running on the server for ~3 weeks now, it seems pretty stable and very effective.
P.P.P.S. That's why I decided to merge it into the upstream.