### PR TITLE
Don't install the module `os` from npm as it's a built-in one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -854,11 +854,6 @@
                 "mimic-fn": "^2.1.0"
             }
         },
-        "os": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
         "discord.js-lavalink-lib": "^0.1.8",
         "inquirer": "^7.3.3",
         "moment": "^2.29.1",
-        "ms": "^2.1.3",
-        "os": "^0.1.1"
+        "ms": "^2.1.3"
     },
     "devDependencies": {
         "@types/inquirer": "^6.5.0",


### PR DESCRIPTION
It probably got added to the dependencies by mistake. See also [its source code](https://github.com/DiegoRBaquero/node-os/blob/0a6cd5c8562e05f4beb2761891c185c16447f48d/index.js).