### PR TITLE
Minor modifications to the '.eco' command

### DIFF
--- a/src/commands/fun/modules/eco-core.ts
+++ b/src/commands/fun/modules/eco-core.ts
@@ -19,7 +19,13 @@ export const DailyCommand = new NamedCommand({
                     embed: {
                         title: "Daily Reward",
                         description: "You received 1 Mon!",
-                        color: ECO_EMBED_COLOR
+                        color: ECO_EMBED_COLOR,
+                        fields: [
+                            {
+                                name: "New balance:",
+                                value: pluralise(user.money, "Mon", "s")
+                            }
+                        ]
                     }
                 });
             } else

--- a/src/commands/fun/modules/eco-utils.ts
+++ b/src/commands/fun/modules/eco-utils.ts
@@ -62,9 +62,17 @@ export function getSendEmbed(sender: User, receiver: User, amount: number): obje
 }
 
 export function isAuthorized(guild: Guild | null, channel: TextChannel | DMChannel | NewsChannel): boolean {
-    if ((guild?.id === "637512823676600330" && channel?.id === "669464416420364288") || IS_DEV_MODE) return true;
-    else {
-        channel.send("Sorry, this command can only be used in Monika's emote server. (#mon-stocks)");
+    if (IS_DEV_MODE) {
+        return true;
+    }
+
+    if (guild?.id !== "637512823676600330") {
+        channel.send("Sorry, this command can only be used in Monika's emote server.");
         return false;
+    } else if (channel?.id === "669464416420364288") {
+        channel.send("Sorry, this command can only be used in <#669464416420364288>.");
+        return false;
+    } else {
+        return true;
     }
 }


### PR DESCRIPTION
_Channel locking:_
Made message sent when using outside of the #mon-stocks channel be a little more clear depending on if it is run in the wrong server, or if it's simply in the wrong channel in Monica's server

_.eco daily_
Made the embed for the .eco daily command now display the new balance of the user calling it.