### PR TITLE
Make .eco daily's cooldown use the new Discord timestamps

### DIFF
--- a/src/commands/fun/modules/eco-core.ts
+++ b/src/commands/fun/modules/eco-core.ts
@@ -33,7 +33,7 @@ export const DailyCommand = new NamedCommand({
                     embed: {
                         title: "Daily Reward",
                         description: `It's too soon to pick up your daily Mons. Try again at <t:${Math.floor(
-                            (user.lastReceived + 79200000 - now) / 1000
+                            (user.lastReceived + 79200000) / 1000
                         )}:t>.`,
                         color: ECO_EMBED_COLOR
                     }

--- a/src/commands/fun/modules/eco-core.ts
+++ b/src/commands/fun/modules/eco-core.ts
@@ -32,10 +32,9 @@ export const DailyCommand = new NamedCommand({
                 send({
                     embed: {
                         title: "Daily Reward",
-                        description: `It's too soon to pick up your daily Mons. You have about ${(
-                            (user.lastReceived + 79200000 - now) /
-                            3600000
-                        ).toFixed(1)} hours to go.`,
+                        description: `It's too soon to pick up your daily Mons. Try again at <t:${Math.floor(
+                            (user.lastReceived + 79200000 - now) / 1000
+                        )}:t>.`,
                         color: ECO_EMBED_COLOR
                     }
                 });


### PR DESCRIPTION
A rather simple change - instead of displaying a message such as "You have about 21.3 hours to go", display the exact time that the cooldown will expire.
 
Example:
![In action!](https://media.discordapp.net/attachments/772203981836910592/861019248733454336/unknown.png)